### PR TITLE
Addition of Attractions page to LogRide

### DIFF
--- a/lib/data/attraction_structures.dart
+++ b/lib/data/attraction_structures.dart
@@ -39,6 +39,7 @@ class BluehostAttraction {
   int yearOpen;
   int yearClosed;
   bool active;
+  bool seasonal;
   bool scoreCard;
   String manufacturer;
   String additionalContributors;
@@ -84,6 +85,7 @@ class BluehostAttraction {
     newAttraction.yearClosed = num.parse(json["YearClosed"]);
 
     newAttraction.active = (json["Active"] == "1");
+    newAttraction.seasonal = (json["Seasonal"] == "1");
     newAttraction.scoreCard = (json["ScoreCard"] == "1");
     newAttraction.manufacturer = json["Manufacturer"];
     newAttraction.additionalContributors = json["additionalContributors"];

--- a/lib/data/attraction_structures.dart
+++ b/lib/data/attraction_structures.dart
@@ -15,8 +15,8 @@ class FirebaseAttraction {
   factory FirebaseAttraction.fromMap(Map<String, dynamic> map){
     FirebaseAttraction newAttraction = FirebaseAttraction(rideID: map["rideID"]);
     newAttraction.numberOfTimesRidden = map["numberOfTimesRidden"];
-    newAttraction.firstRideDate = DateTime.fromMillisecondsSinceEpoch((map["firstRideDate"] as double).toInt());
-    newAttraction.lastRideDate = DateTime.fromMillisecondsSinceEpoch((map["lastRideDate"] as double).toInt());
+    newAttraction.firstRideDate = DateTime.fromMillisecondsSinceEpoch((map["firstRideDate"] as num).toInt());
+    newAttraction.lastRideDate = DateTime.fromMillisecondsSinceEpoch((map["lastRideDate"] as num).toInt());
     return newAttraction;
   }
 

--- a/lib/data/attraction_structures.dart
+++ b/lib/data/attraction_structures.dart
@@ -10,8 +10,8 @@ class FirebaseAttraction {
   factory FirebaseAttraction.fromMap(Map<String, dynamic> map){
     FirebaseAttraction newAttraction = FirebaseAttraction(rideID: map["rideID"]);
     newAttraction.numberOfTimesRidden = map["numberOfTimesRidden"];
-    newAttraction.firstRideDate = map["firstRideDate"];
-    newAttraction.lastRideDate = map["lastRideDate"];
+    newAttraction.firstRideDate = DateTime.fromMillisecondsSinceEpoch((map["firstRideDate"] as double).toInt());
+    newAttraction.lastRideDate = DateTime.fromMillisecondsSinceEpoch((map["lastRideDate"] as double).toInt());
     return newAttraction;
   }
 

--- a/lib/data/attraction_structures.dart
+++ b/lib/data/attraction_structures.dart
@@ -5,6 +5,11 @@ class FirebaseAttraction {
   DateTime firstRideDate = DateTime.fromMillisecondsSinceEpoch(0);
   DateTime lastRideDate = DateTime.fromMillisecondsSinceEpoch(0);
 
+  // Note: This variable is NOT assigned or stored in the standard firebase map
+  // This is from a different portion, and is managed by the attraction list
+  // page's logic
+  bool ignored = false;
+
   FirebaseAttraction({this.rideID});
 
   factory FirebaseAttraction.fromMap(Map<String, dynamic> map){

--- a/lib/data/fbdb_manager.dart
+++ b/lib/data/fbdb_manager.dart
@@ -23,14 +23,15 @@ Map<DatabasePath, String> _databasePathStrings = {
 };
 
 abstract class BaseDB {
-  Query getSortedQueryForUser({DatabasePath path, String userID, String key});
-  Query getFilteredQuery({DatabasePath path, String userID, String key, dynamic value});
-  Query getQueryForUser({DatabasePath path, String userID, String key});
-  void setEntryAtPath({DatabasePath path, String userID, String key, dynamic payload});
-  void removeEntryFromPath({DatabasePath path, String userID, String key});
-  Future<bool> doesEntryExistAtPath({DatabasePath path, String userID, String key});
-  Future<dynamic> getEntryAtPath({DatabasePath path, String userID, String key});
-  Stream<Event> getLiveEntryAtPath({DatabasePath path, String userID, String key});
+  Query getSortedQueryForUser({DatabasePath path, String key});
+  Query getFilteredQuery({DatabasePath path, String key, dynamic value});
+  Query getQueryForUser({DatabasePath path, String key});
+  void setEntryAtPath({DatabasePath path, String key, dynamic payload});
+  void updateEntryAtPath({DatabasePath path, String key, dynamic payload});
+  void removeEntryFromPath({DatabasePath path, String key});
+  Future<bool> doesEntryExistAtPath({DatabasePath path, String key});
+  Future<dynamic> getEntryAtPath({DatabasePath path, String key});
+  Stream<Event> getLiveEntryAtPath({DatabasePath path, String key});
   void storeUserID(String userID);
   void clearUserID();
 }
@@ -52,44 +53,48 @@ class DatabaseManager implements BaseDB {
     return _firebaseDatabase.reference().child(childPath);
   }
 
-  Query getSortedQueryForUser({DatabasePath path, String userID, String key}){
-    return _getReference(path).child(userID ?? _savedID).orderByChild(key);
+  Query getSortedQueryForUser({DatabasePath path, String key}){
+    return _getReference(path).child(_savedID).orderByChild(key);
   }
 
-  Query getFilteredQuery({DatabasePath path, String userID, String key, dynamic value}){
-    return _getReference(path).child(userID ?? _savedID).orderByChild(key).equalTo(value);
+  Query getFilteredQuery({DatabasePath path, String key, dynamic value}){
+    return _getReference(path).child(_savedID).orderByChild(key).equalTo(value);
   }
 
-  Query getQueryForUser({DatabasePath path, String userID, String key}) {
-    return _getReference(path).child(userID ?? _savedID).orderByKey();
+  Query getQueryForUser({DatabasePath path, String key}) {
+    return _getReference(path).child(_savedID).orderByKey();
   }
 
-  void removeEntryFromPath({DatabasePath path, String userID, String key}){
-    _getReference(path).child(userID ?? _savedID).child(key).remove();
+  void removeEntryFromPath({DatabasePath path, String key}){
+    _getReference(path).child(_savedID).child(key).remove();
   }
 
-  void setEntryAtPath({DatabasePath path, String userID, String key, dynamic payload}){
-    _getReference(path).child(userID ?? _savedID).child(key).set(payload);
+  void setEntryAtPath({DatabasePath path, String key, dynamic payload}){
+    _getReference(path).child(_savedID).child(key).set(payload);
   }
 
-  Future<bool> doesEntryExistAtPath({DatabasePath path, String userID, String key}) {
-    return _getReference(path).child(userID ?? _savedID).child(key).once().then((DataSnapshot snapshot) {
+  void updateEntryAtPath({DatabasePath path, String key, dynamic payload}) {
+    _getReference(path).child(_savedID).child(key).update(payload);
+  }
+
+  Future<bool> doesEntryExistAtPath({DatabasePath path, String key}) {
+    return _getReference(path).child(_savedID).child(key).once().then((DataSnapshot snapshot) {
       return snapshot.value != null;
     });
   }
 
-  Future<dynamic> getEntryAtPath({DatabasePath path, String userID, String key}) {
-    return _getReference(path).child(userID ?? _savedID).child(key).once().then((DataSnapshot snapshot) {
+  Future<dynamic> getEntryAtPath({DatabasePath path, String key}) {
+    return _getReference(path).child(_savedID).child(key).once().then((DataSnapshot snapshot) {
       return snapshot.value;
     });
   }
 
-  Stream<Event> getLiveEntryAtPath({DatabasePath path, String userID, String key}) {
-    return _getReference(path).child(userID ?? _savedID).child(key).onValue;
+  Stream<Event> getLiveEntryAtPath({DatabasePath path, String key}) {
+    return _getReference(path).child(_savedID).child(key).onValue;
   }
 
-  Stream<Event> getLiveChildrenChanges({DatabasePath path, String userID, String key}) {
-    return _getReference(path).child(userID ?? _savedID).child(key).onChildChanged;
+  Stream<Event> getLiveChildrenChanges({DatabasePath path, String key}) {
+    return _getReference(path).child(_savedID).child(key).onChildChanged;
   }
 
 }

--- a/lib/data/fbdb_manager.dart
+++ b/lib/data/fbdb_manager.dart
@@ -27,7 +27,7 @@ abstract class BaseDB {
   Query getFilteredQuery({DatabasePath path, String key, dynamic value});
   Query getQueryForUser({DatabasePath path, String key});
   void setEntryAtPath({DatabasePath path, String key, dynamic payload});
-  void updateEntryAtPath({DatabasePath path, String key, dynamic payload});
+  void updateEntryAtPath({DatabasePath path, String key, Map<String, dynamic> payload});
   void removeEntryFromPath({DatabasePath path, String key});
   Future<bool> doesEntryExistAtPath({DatabasePath path, String key});
   Future<dynamic> getEntryAtPath({DatabasePath path, String key});
@@ -73,7 +73,7 @@ class DatabaseManager implements BaseDB {
     _getReference(path).child(_savedID).child(key).set(payload);
   }
 
-  void updateEntryAtPath({DatabasePath path, String key, dynamic payload}) {
+  void updateEntryAtPath({DatabasePath path, String key, Map<String, dynamic> payload}) {
     _getReference(path).child(_savedID).child(key).update(payload);
   }
 

--- a/lib/data/fbdb_manager.dart
+++ b/lib/data/fbdb_manager.dart
@@ -88,4 +88,8 @@ class DatabaseManager implements BaseDB {
     return _getReference(path).child(userID ?? _savedID).child(key).onValue;
   }
 
+  Stream<Event> getLiveChildrenChanges({DatabasePath path, String userID, String key}) {
+    return _getReference(path).child(userID ?? _savedID).child(key).onChildChanged;
+  }
+
 }

--- a/lib/data/fbdb_manager.dart
+++ b/lib/data/fbdb_manager.dart
@@ -23,6 +23,7 @@ Map<DatabasePath, String> _databasePathStrings = {
 };
 
 abstract class BaseDB {
+  void init();
   Query getSortedQueryForUser({DatabasePath path, String key});
   Query getFilteredQuery({DatabasePath path, String key, dynamic value});
   Query getQueryForUser({DatabasePath path, String key});
@@ -32,6 +33,7 @@ abstract class BaseDB {
   Future<bool> doesEntryExistAtPath({DatabasePath path, String key});
   Future<dynamic> getEntryAtPath({DatabasePath path, String key});
   Stream<Event> getLiveEntryAtPath({DatabasePath path, String key});
+  Stream<Event> getLiveChildrenChanges({DatabasePath path, String key});
   void storeUserID(String userID);
   void clearUserID();
 }
@@ -39,6 +41,10 @@ abstract class BaseDB {
 class DatabaseManager implements BaseDB {
   final FirebaseDatabase _firebaseDatabase = FirebaseDatabase.instance;
   String _savedID;
+
+  void init(){
+    _firebaseDatabase.setPersistenceEnabled(true);
+  }
 
   void storeUserID(String userID){
     _savedID = userID ?? null;
@@ -62,7 +68,7 @@ class DatabaseManager implements BaseDB {
   }
 
   Query getQueryForUser({DatabasePath path, String key}) {
-    return _getReference(path).child(_savedID).orderByKey();
+    return _getReference(path).child(_savedID).child(key).orderByKey();
   }
 
   void removeEntryFromPath({DatabasePath path, String key}){

--- a/lib/data/park_structures.dart
+++ b/lib/data/park_structures.dart
@@ -14,7 +14,7 @@ class FirebasePark {
   final int parkID;
   int ridesRidden = 0;
   bool showDefunct = false;
-  bool showSeasonal = true;
+  bool showSeasonal = false;
   int totalRides = 0;
 
   FirebasePark({this.parkID, this.name, this.location});
@@ -33,7 +33,7 @@ class FirebasePark {
     newPark.numDefunctRidden = data["defunctRidden"] ?? 0;
     newPark.numSeasonalRidden = data["seasonalRidden"] ?? 0;
     newPark.showDefunct = data["showDefunct"];
-    newPark.showSeasonal = data["showSeasonal"] ?? true;
+    newPark.showSeasonal = data["showSeasonal"] ?? false;
     newPark.totalRides = data["totalRides"];
     return newPark;
   }

--- a/lib/data/park_structures.dart
+++ b/lib/data/park_structures.dart
@@ -13,6 +13,7 @@ class FirebasePark {
   final int parkID;
   int ridesRidden = 0;
   bool showDefunct = false;
+  bool showSeasonal = true;
   int totalRides = 0;
 
   FirebasePark({this.parkID, this.name, this.location});
@@ -29,6 +30,7 @@ class FirebasePark {
     newPark.numberOfCheckIns = data["numberOfCheckIns"];
     newPark.ridesRidden = data["ridesRidden"];
     newPark.showDefunct = data["showDefunct"];
+    newPark.showSeasonal = data["showSeasonal"] ?? true;
     newPark.totalRides = data["totalRides"];
     return newPark;
   }
@@ -45,6 +47,7 @@ class FirebasePark {
       "numberOfCheckIns": this.numberOfCheckIns,
       "ridesRidden": this.ridesRidden,
       "showDefunct": this.showDefunct,
+      "showSeasonal": this.showSeasonal,
       "totalRides": this.totalRides
     };
   }

--- a/lib/data/park_structures.dart
+++ b/lib/data/park_structures.dart
@@ -9,7 +9,9 @@ class FirebasePark {
   String location = "";
   String name = "";
   int numberOfCheckIns = 0;
-  int numDefunctRidden = 0;
+  int numDefunctRidden =
+      0; // These two num riddens are not stored in the firebase
+  int numSeasonalRidden = 0; // Calculated by clients
   final int parkID;
   int ridesRidden = 0;
   bool showDefunct = false;
@@ -53,9 +55,12 @@ class FirebasePark {
   }
 
   void updateAttractionCount(
-      {BluehostPark targetPark, List<FirebaseAttraction> userData, List<int> ignored}) {
+      {BluehostPark targetPark,
+      List<FirebaseAttraction> userData,
+      List<int> ignored}) {
     if (targetPark == null) {
       this.numDefunctRidden = 0;
+      this.numSeasonalRidden = 0;
       this.ridesRidden = 0;
       this.totalRides = 0;
       return;
@@ -67,6 +72,7 @@ class FirebasePark {
     int numAttractions = 0;
     int numRidden = 0;
     int numDefunctRidden = 0;
+    int numSeasonalRidden = 0;
 
     for (int i = 0; i < targetPark.attractions.length; i++) {
       BluehostAttraction serverAttraction = targetPark.attractions[i];
@@ -74,15 +80,20 @@ class FirebasePark {
           userData, serverAttraction.attractionID);
 
       // If it's ignored, it doesn't contribute to total ride count
-      if(ignored.contains(serverAttraction.attractionID)) continue;
+      if (ignored.contains(serverAttraction.attractionID)) continue;
 
       // If it's defunct, it only adds to the defunct count if it's been ridden
       if (!serverAttraction.active) {
-
-        if((userAttraction?.numberOfTimesRidden ?? -1) > 0) {
+        if ((userAttraction?.numberOfTimesRidden ?? -1) > 0) {
           numDefunctRidden++;
         }
+        continue;
+      }
 
+      if (serverAttraction.seasonal) {
+        if ((userAttraction?.numberOfTimesRidden ?? -1) > 0) {
+          numSeasonalRidden++;
+        }
         continue;
       }
 
@@ -92,6 +103,7 @@ class FirebasePark {
     }
 
     this.numDefunctRidden = numDefunctRidden;
+    this.numSeasonalRidden = numSeasonalRidden;
     this.ridesRidden = numRidden;
     this.totalRides = numAttractions;
   }

--- a/lib/data/park_structures.dart
+++ b/lib/data/park_structures.dart
@@ -9,9 +9,8 @@ class FirebasePark {
   String location = "";
   String name = "";
   int numberOfCheckIns = 0;
-  int numDefunctRidden =
-      0; // These two num riddens are not stored in the firebase
-  int numSeasonalRidden = 0; // Calculated by clients
+  int numDefunctRidden = 0;
+  int numSeasonalRidden = 0;
   final int parkID;
   int ridesRidden = 0;
   bool showDefunct = false;
@@ -31,6 +30,8 @@ class FirebasePark {
     newPark.name = data["name"];
     newPark.numberOfCheckIns = data["numberOfCheckIns"];
     newPark.ridesRidden = data["ridesRidden"];
+    newPark.numDefunctRidden = data["defunctRidden"] ?? 0;
+    newPark.numSeasonalRidden = data["seasonalRidden"] ?? 0;
     newPark.showDefunct = data["showDefunct"];
     newPark.showSeasonal = data["showSeasonal"] ?? true;
     newPark.totalRides = data["totalRides"];
@@ -48,6 +49,8 @@ class FirebasePark {
       "name": this.name,
       "numberOfCheckIns": this.numberOfCheckIns,
       "ridesRidden": this.ridesRidden,
+      "defunctRidden": this.numDefunctRidden,
+      "seasonalRidden": this.numSeasonalRidden,
       "showDefunct": this.showDefunct,
       "showSeasonal": this.showSeasonal,
       "totalRides": this.totalRides

--- a/lib/data/park_structures.dart
+++ b/lib/data/park_structures.dart
@@ -33,8 +33,8 @@ class FirebasePark {
     return newPark;
   }
 
-  Map toMap() {
-    return {
+  Map<String, dynamic> toMap() {
+    return <String, dynamic>{
       "parkID": this.parkID,
       "checkedInToday": this.checkedInToday,
       "favorite": this.favorite,
@@ -50,7 +50,7 @@ class FirebasePark {
   }
 
   void updateAttractionCount(
-      {BluehostPark targetPark, List<FirebaseAttraction> userData}) {
+      {BluehostPark targetPark, List<FirebaseAttraction> userData, List<int> ignored}) {
     if (targetPark == null) {
       this.numDefunctRidden = 0;
       this.ridesRidden = 0;
@@ -59,25 +59,36 @@ class FirebasePark {
     }
     // Create an empty list so the search doesn't fail
     if (userData == null) userData = List<FirebaseAttraction>();
+    if (ignored == null) ignored = List<int>();
 
     int numAttractions = 0;
     int numRidden = 0;
-    int numDefunct = 0;
+    int numDefunctRidden = 0;
 
     for (int i = 0; i < targetPark.attractions.length; i++) {
+      BluehostAttraction serverAttraction = targetPark.attractions[i];
       FirebaseAttraction userAttraction = getFirebaseAttractionFromList(
-          userData, targetPark.attractions[i].attractionID);
-      if (!targetPark.attractions[i].active &&
-          (userAttraction?.numberOfTimesRidden ?? -1) > 0) {
-        numDefunct++;
+          userData, serverAttraction.attractionID);
+
+      // If it's ignored, it doesn't contribute to total ride count
+      if(ignored.contains(serverAttraction.attractionID)) continue;
+
+      // If it's defunct, it only adds to the defunct count if it's been ridden
+      if (!serverAttraction.active) {
+
+        if((userAttraction?.numberOfTimesRidden ?? -1) > 0) {
+          numDefunctRidden++;
+        }
+
         continue;
       }
 
+      // Add to the total count, but only add to the ridden count if it's actually been ridden
       numAttractions++;
       if ((userAttraction?.numberOfTimesRidden ?? -1) > 0) numRidden++;
     }
 
-    this.numDefunctRidden = numDefunct;
+    this.numDefunctRidden = numDefunctRidden;
     this.ridesRidden = numRidden;
     this.totalRides = numAttractions;
   }

--- a/lib/data/parks_manager.dart
+++ b/lib/data/parks_manager.dart
@@ -28,9 +28,12 @@ class ParksManager {
     // Go through and set-up the allParksInfo to match the user database.
     // The 'filled' tag is used in the all-parks-search to show the user they
     // have that park.
-    db
-        .getEntryAtPath(path: DatabasePath.PARKS, key: "")
-        .then((snap) async {
+    db.getEntryAtPath(path: DatabasePath.PARKS, key: "").then((snap) async {
+      if (snap == null) {
+        print("User has no data currently. Returning.");
+        searchInitialized = true;
+        return;
+      }
       Map<dynamic, dynamic> values = jsonDecode(jsonEncode(snap));
       for (int i = 0; i < values.keys.length; i++) {
         int entryID = num.parse(values.keys.elementAt(i));
@@ -42,8 +45,8 @@ class ParksManager {
         wf
             .getAllAttractionData(
                 parkID: targetPark.id, rideTypes: attractionTypes)
-            .then((list){
-              targetPark.attractions = list;
+            .then((list) {
+          targetPark.attractions = list;
         });
         targetPark.filled = true;
       }
@@ -109,14 +112,20 @@ class ParksManager {
         payload: false);
   }
 
-  void updateAttractionCount(FirebasePark targetFBPark, List<int> ignoredAttractionIDs, List<FirebaseAttraction> userAttractionData) {
-    BluehostPark targetBHPark = getBluehostParkByID(allParksInfo, targetFBPark.parkID);
-    targetFBPark.updateAttractionCount(targetPark: targetBHPark, userData: userAttractionData, ignored: ignoredAttractionIDs);
+  void updateAttractionCount(
+      FirebasePark targetFBPark,
+      List<int> ignoredAttractionIDs,
+      List<FirebaseAttraction> userAttractionData) {
+    BluehostPark targetBHPark =
+        getBluehostParkByID(allParksInfo, targetFBPark.parkID);
+    targetFBPark.updateAttractionCount(
+        targetPark: targetBHPark,
+        userData: userAttractionData,
+        ignored: ignoredAttractionIDs);
 
     db.updateEntryAtPath(
-      path: DatabasePath.PARKS, key: targetFBPark.parkID.toString(),
-      payload: targetFBPark.toMap()
-    );
-
+        path: DatabasePath.PARKS,
+        key: targetFBPark.parkID.toString(),
+        payload: targetFBPark.toMap());
   }
 }

--- a/lib/data/parks_manager.dart
+++ b/lib/data/parks_manager.dart
@@ -108,4 +108,15 @@ class ParksManager {
         key: targetID.toString() + "/favorite",
         payload: false);
   }
+
+  void updateAttractionCount(FirebasePark targetFBPark, List<int> ignoredAttractionIDs, List<FirebaseAttraction> userAttractionData) {
+    BluehostPark targetBHPark = getBluehostParkByID(allParksInfo, targetFBPark.parkID);
+    targetFBPark.updateAttractionCount(targetPark: targetBHPark, userData: userAttractionData, ignored: ignoredAttractionIDs);
+
+    db.updateEntryAtPath(
+      path: DatabasePath.PARKS, key: targetFBPark.parkID.toString(),
+      payload: targetFBPark.toMap()
+    );
+
+  }
 }

--- a/lib/data/webfetcher.dart
+++ b/lib/data/webfetcher.dart
@@ -25,6 +25,7 @@ class WebFetcher {
     final response = await http.get(_serverURLS[WebLocation.ALL_PARKS]);
 
     if(response.statusCode == 200){
+
       List<dynamic> decoded = json.decode(response.body);
 
       for(int i = 0; i < decoded.length; i++){
@@ -44,6 +45,7 @@ class WebFetcher {
       List<dynamic> decoded = jsonDecode(response.body);
       for(int i =0; i < decoded.length; i++){
         BluehostAttraction newAttraction = BluehostAttraction.fromJson(decoded[i]);
+        _fixBluehostText(newAttraction);
 
         // Get our type label, or leave it blank if it doesn't exist
         newAttraction.typeLabel = rideTypes[newAttraction.rideType] ?? "";
@@ -59,6 +61,8 @@ class WebFetcher {
     final response = await http.get(_serverURLS[WebLocation.SPECIFIC_ATTRACTION] + attractionID.toString());
 
     if(response.statusCode == 200){
+      BluehostAttraction createdAttraction = BluehostAttraction.fromJson(jsonDecode(response.body));
+      _fixBluehostText(createdAttraction);
       return BluehostAttraction.fromJson(jsonDecode(response.body));
     }
 
@@ -78,4 +82,22 @@ class WebFetcher {
 
     return null;
   }
+}
+
+String rosettaStoneDecode(String input, {bool insertAmpersands = true, bool insertSpaces = true}){
+  String result = input;
+  if(insertAmpersands) result = result.replaceAll("!A?", "&");
+  if(insertSpaces) result = result.replaceAll("_", " ");
+
+  return result;
+}
+
+/// This is used to swap specific characters out that couldn't be used in standard web GET requests.
+/// These characters were swapped by the original app during the submission process, which used
+/// GET requests. These alternate characters were stored in the database. Now we
+/// must filter them out for the text to be readable.
+void _fixBluehostText(BluehostAttraction toFix){
+  if(toFix.attractionName != null) toFix.attractionName = rosettaStoneDecode(toFix.attractionName);
+  if(toFix.manufacturer != null) toFix.manufacturer = rosettaStoneDecode(toFix.manufacturer, insertSpaces: false);
+  return;
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,9 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    BaseDB db = DatabaseManager();
+    db.init();
+
     return MaterialApp(
         title: 'LogRide',
         routes: <String, WidgetBuilder>{
@@ -30,7 +33,7 @@ class MyApp extends StatelessWidget {
                   fontSize: 28.0,
                   fontWeight: FontWeight.bold
                 ))),
-        home: LandingPage(auth: Auth(), db: DatabaseManager(),));
+        home: LandingPage(auth: Auth(), db: db,));
   }
 }
 

--- a/lib/ui/attractions_list_page.dart
+++ b/lib/ui/attractions_list_page.dart
@@ -84,7 +84,7 @@ class _AttractionsPageState extends State<AttractionsPage> {
                     // Titlebar w/ info and settings buttons
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                      child: _buildTitleBar(context),
+                      child: _buildTitleBar(context, parkData),
                     ),
 
                     // Percentage Complete bar
@@ -117,7 +117,7 @@ class _AttractionsPageState extends State<AttractionsPage> {
   /// Returns the titlebar used in [AttractionListPage]. Contains two buttons,
   /// settings and info, separated by an expanded text that contains the name of
   /// the park.
-  Widget _buildTitleBar(BuildContext context) {
+  Widget _buildTitleBar(BuildContext context, FirebasePark parkData) {
     return Padding(
       padding: const EdgeInsets.only(bottom: 8.0),
       child: Container(
@@ -138,8 +138,12 @@ class _AttractionsPageState extends State<AttractionsPage> {
             ),
           ),
           // Right icon
+          /// TODO: REPLACE WITH PROPER SETTINGS PAGE
           _buildTitleBarIcon(context,
-              icon: FontAwesomeIcons.cog, onTap: () => print("Setings")),
+              icon: FontAwesomeIcons.cog, onTap: () {
+              parkData.incrementorEnabled = !parkData.incrementorEnabled;
+              widget.db.setEntryAtPath(path: DatabasePath.PARKS, key: parkData.parkID.toString(), payload: parkData.toMap());
+            })
         ],
       )),
     );

--- a/lib/ui/attractions_list_page.dart
+++ b/lib/ui/attractions_list_page.dart
@@ -89,18 +89,19 @@ class _AttractionsPageState extends State<AttractionsPage> {
 
                     // Percentage Complete bar
                     ParkProgressFullBar(
-                      numRidden: parkData.ridesRidden,
-                      numRides: parkData.totalRides,
-                      defunctRidden: parkData.numDefunctRidden,
-                      showDefunct: parkData.showDefunct,
-                    ),
+                        numRidden: parkData.ridesRidden,
+                        numRides: parkData.totalRides,
+                        defunctRidden: parkData.numDefunctRidden,
+                        showDefunct: parkData.showDefunct,
+                      ),
 
                     // Listview (Expanded)
-                    // TODO: Implement ListView display for the attractions themselves
                     Expanded(
                       child: AttractionsListView(
                         sourceAttractions: widget.serverParkData.attractions,
                         parentPark: parkData,
+                        slidableController: _slidableController,
+                        pm: widget.pm,
                         db: widget.db,
                         // Data here
                       )

--- a/lib/ui/attractions_list_page.dart
+++ b/lib/ui/attractions_list_page.dart
@@ -31,8 +31,6 @@ class _AttractionsPageState extends State<AttractionsPage>
 
   double lastRatio = 0.0;
 
-  /// TODO: ANIMATE AND MANAGE THE STATE OF THESE FOR THE THING
-
   @override
   void initState() {
     _parkStream = widget.db.getLiveEntryAtPath(
@@ -72,10 +70,10 @@ class _AttractionsPageState extends State<AttractionsPage>
               FirebasePark parkData = FirebasePark.fromMap(parkDataMap);
               print("Successfully recived parkData for attractions list page");
 
-
               double tempOldRatio = lastRatio;
               lastRatio = 0.0;
-              if(parkData.totalRides != 0) lastRatio = parkData.ridesRidden / parkData.totalRides;
+              if (parkData.totalRides != 0)
+                lastRatio = parkData.ridesRidden / parkData.totalRides;
 
               return Column(children: <Widget>[
                 // Padding used to make sure the iconButton doesn't overlap
@@ -93,13 +91,13 @@ class _AttractionsPageState extends State<AttractionsPage>
 
                 // Percentage Complete bar
                 FullParkProgressBar(
+                  oldRatio: tempOldRatio,
+                  showSeasonal: parkData.showSeasonal,
                   showDefunct: parkData.showDefunct,
-                  showSeasonal:  parkData.showSeasonal,
                   totalCount: parkData.totalRides,
                   riddenCount: parkData.ridesRidden,
-                  defunctCount: parkData.numDefunctRidden,
                   seasonalCount: parkData.numSeasonalRidden,
-                  oldRatio: tempOldRatio,
+                  defunctCount: parkData.numDefunctRidden,
                 ),
 
                 // Listview (Expanded)

--- a/lib/ui/attractions_list_page.dart
+++ b/lib/ui/attractions_list_page.dart
@@ -28,10 +28,6 @@ class _AttractionsPageState extends State<AttractionsPage> {
 
   Stream<Event> _parkStream;
 
-  void _handleExperienceTap(num parkID) {}
-
-  void _handleExperienceLongTap(num parkID) {}
-
   @override
   void initState() {
     _parkStream = widget.db.getLiveEntryAtPath(

--- a/lib/ui/home.dart
+++ b/lib/ui/home.dart
@@ -206,22 +206,29 @@ class _HomePageState extends State<HomePage> {
       builder: (context, snapshot) {
         if (!snapshot.hasData) {
           return Center(
-              child: Card(
-                  shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(15)),
-                  child: Padding(
-                    padding: const EdgeInsets.all(16.0),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: <Widget>[
-                        CircularProgressIndicator(),
-                        Padding(
-                          padding: const EdgeInsets.only(top: 8.0),
-                          child: Text("Loading Park Information..."),
-                        )
-                      ],
-                    ),
-                  )));
+              child: Container(
+                width: MediaQuery.of(context).size.width * 2 / 5,
+                child: Card(
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(15)),
+                      child: AspectRatio(
+                          aspectRatio: 1,
+                          child: Padding(
+                        padding: const EdgeInsets.all(16.0),
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.spaceAround,
+                          mainAxisSize: MainAxisSize.min,
+                          children: <Widget>[
+                            CircularProgressIndicator(),
+                            Padding(
+                              padding: const EdgeInsets.only(top: 8.0),
+                              child: Text("Loading Park Information...", textAlign: TextAlign.center,),
+                            )
+                          ],
+                        ),
+                      )),
+                ),
+              ));
         } else if (snapshot.data) {
           // Since data is a bool, if it's true, we'll do this thing
           return ContentFrame(

--- a/lib/widgets/attraction_list_entry.dart
+++ b/lib/widgets/attraction_list_entry.dart
@@ -22,34 +22,33 @@ class AttractionListEntry extends StatelessWidget {
   Widget build(BuildContext context) {
     Widget built;
 
-    Color tileColor = ignored || !attractionData.active ? Theme.of(context).disabledColor : Colors.white;
+    Color tileColor = ignored || !attractionData.active
+        ? Theme.of(context).disabledColor
+        : Colors.white;
 
-    built = InkWell(
-      onTap: _onInfoTap,
-      child: Container(
-        color: tileColor,
-        constraints: BoxConstraints.expand(height: 58.0),
-        padding: EdgeInsets.symmetric(vertical: 2.0, horizontal: 12.0),
-        child: Row(
-          children: <Widget>[
-            Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                AutoSizeText(
-                  attractionData.attractionName,
-                  maxLines: 1,
-                  style: Theme.of(context).textTheme.subhead,
-                ),
-                AutoSizeText(
-                  attractionData.typeLabel,
-                  maxLines: 1,
-                  style: Theme.of(context).textTheme.subtitle
-                )
-              ],
-            ))
-          ],
-        ),
+    built = Container(
+      color: tileColor,
+      constraints: BoxConstraints.expand(height: 58.0),
+      padding: EdgeInsets.symmetric(vertical: 2.0, horizontal: 12.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          Expanded(
+              child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              AutoSizeText(
+                attractionData.attractionName,
+                maxLines: 1,
+                style: Theme.of(context).textTheme.subhead,
+              ),
+              AutoSizeText(attractionData.typeLabel,
+                  maxLines: 1, style: Theme.of(context).textTheme.subtitle)
+            ],
+          )),
+          buttonWidget ?? Container()
+        ],
       ),
     );
 

--- a/lib/widgets/attraction_list_entry.dart
+++ b/lib/widgets/attraction_list_entry.dart
@@ -12,7 +12,7 @@ class AttractionListEntry extends StatefulWidget {
         this.userData,
         this.slidableController,
         this.ignoreCallback,
-      this.interactHandler,
+      this.experienceHandler,
       this.parentPark});
 
   final BluehostAttraction attractionData;
@@ -20,7 +20,7 @@ class AttractionListEntry extends StatefulWidget {
   final FirebasePark parentPark;
   final SlidableController slidableController;
   final Function(BluehostAttraction, bool) ignoreCallback;
-  final Function interactHandler;
+  final Function(ExperienceAction, FirebaseAttraction) experienceHandler;
 
   @override
   State<StatefulWidget> createState() => AttractionListState();
@@ -65,7 +65,7 @@ class AttractionListState extends State<AttractionListEntry>{
           )),
           // If the button's not there for any reason, just show an empty container instead. Prevents null errors.
           ExperienceButton(
-            interactHandler: widget.interactHandler,
+            interactHandler: widget.experienceHandler,
             parentPark: widget.parentPark,
             ignored: ignored ?? false,
             data: widget.userData ?? FirebaseAttraction(rideID: widget.attractionData.attractionID),

--- a/lib/widgets/attraction_list_widget.dart
+++ b/lib/widgets/attraction_list_widget.dart
@@ -32,8 +32,6 @@ class _AttractionsListViewState extends State<AttractionsListView> {
   Map<String, List<BluehostAttraction>> displayLists;
   List<int> ignoreList;
 
-  Stream<Event> _attractionsStream;
-
   List<FirebaseAttraction> fullList;
 
   List<dynamic> headedList;

--- a/lib/widgets/attraction_list_widget.dart
+++ b/lib/widgets/attraction_list_widget.dart
@@ -38,14 +38,19 @@ class _AttractionsListViewState extends State<AttractionsListView> {
 
   Map<String, List<BluehostAttraction>> _buildPreparedList() {
     headedList = List<dynamic>();
+
     List<BluehostAttraction> activeList = List<BluehostAttraction>(),
         seasonalList = List<BluehostAttraction>(),
         defunctList = List<BluehostAttraction>();
-    // Split each attraction into their separate lists (NOTE: SEASONAL IS NOT IMPLEMENTED YET)
-    // TODO: Seasonal, once data is in place
+
+    // Split each attraction into their separate lists
     for (int i = 0; i < widget.sourceAttractions.length; i++) {
-      if (widget.sourceAttractions[i].active == true) {
-        activeList.add(widget.sourceAttractions[i]);
+      if (widget.sourceAttractions[i].active) {
+        if(widget.sourceAttractions[i].seasonal) {
+          seasonalList.add(widget.sourceAttractions[i]);
+        } else {
+          activeList.add(widget.sourceAttractions[i]);
+        }
       } else {
         defunctList.add(widget.sourceAttractions[i]);
       }
@@ -56,17 +61,21 @@ class _AttractionsListViewState extends State<AttractionsListView> {
     }
 
     activeList.sort(attractionComparator);
+    seasonalList.sort(attractionComparator);
     defunctList.sort(attractionComparator);
 
     bool _hasActive = (activeList.length != 0);
+    bool _hasSeasonal = (seasonalList.length != 0);
     bool _hasDefunct = (defunctList.length != 0);
 
     print("ActiveList => Data: $_hasActive | Length: ${activeList.length}");
+    print("SeasonalList => Data: $_hasSeasonal | Length: ${seasonalList.length}");
     print("DefunctList => Data: $_hasDefunct | Length: ${defunctList.length}");
 
     Map<String, List<BluehostAttraction>> returnMap = Map();
 
     if (_hasActive) returnMap["Active"] = activeList;
+    if (_hasSeasonal) returnMap["Seasonal"] = seasonalList;
     if (_hasDefunct) returnMap["Defunct"] = defunctList;
 
     // Strings are used as headers for the list. These are checked for in the
@@ -77,10 +86,16 @@ class _AttractionsListViewState extends State<AttractionsListView> {
       headedList.addAll(activeList);
     }
 
+    if (_hasSeasonal) {
+      headedList.add("Seasonal");
+      headedList.addAll(seasonalList);
+    }
+
     if (_hasDefunct) {
       headedList.add("Defunct");
       headedList.addAll(defunctList);
     }
+
 
     return returnMap;
   }

--- a/lib/widgets/attraction_list_widget.dart
+++ b/lib/widgets/attraction_list_widget.dart
@@ -73,8 +73,8 @@ class _AttractionsListViewState extends State<AttractionsListView> {
     Map<String, List<BluehostAttraction>> returnMap = Map();
 
     if (_hasActive) returnMap["Active"] = activeList;
-    if (_hasSeasonal) returnMap["Seasonal"] = seasonalList;
-    if (_hasDefunct) returnMap["Defunct"] = defunctList;
+    if (_hasSeasonal && widget.parentPark.showSeasonal) returnMap["Seasonal"] = seasonalList;
+    if (_hasDefunct && widget.parentPark.showDefunct) returnMap["Defunct"] = defunctList;
 
     // Strings are used as headers for the list. These are checked for in the
     // Build functions for the listview.
@@ -85,13 +85,13 @@ class _AttractionsListViewState extends State<AttractionsListView> {
       fullList.addAll(activeList);
     }
 
-    if (_hasSeasonal) {
+    if (_hasSeasonal && widget.parentPark.showSeasonal) {
       headedList.add("Seasonal");
       headedList.addAll(seasonalList);
       fullList.addAll(seasonalList);
     }
 
-    if (_hasDefunct) {
+    if (_hasDefunct && widget.parentPark.showDefunct) {
       headedList.add("Defunct");
       headedList.addAll(defunctList);
       fullList.addAll(seasonalList);
@@ -128,12 +128,12 @@ class _AttractionsListViewState extends State<AttractionsListView> {
   @override
   void initState() {
     super.initState();
-
-    displayLists = _buildPreparedList();
+    //displayLists = _buildPreparedList();
   }
 
   @override
   Widget build(BuildContext context) {
+    displayLists = _buildPreparedList();
     return ClipRRect(
         borderRadius: BorderRadius.only(
             bottomLeft: Radius.circular(15), bottomRight: Radius.circular(15)),

--- a/lib/widgets/experience_button.dart
+++ b/lib/widgets/experience_button.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import '../data/attraction_structures.dart';
+import '../data/park_structures.dart';
 
 class ExperienceButton extends StatelessWidget {
-  ExperienceButton({this.data, this.enabled});
+  ExperienceButton({this.parentPark, this.data, this.ignored});
 
+  final FirebasePark parentPark;
   final FirebaseAttraction data;
-  final bool enabled;
+  final bool ignored;
 
   @override
   Widget build(BuildContext context) {
@@ -13,8 +16,13 @@ class ExperienceButton extends StatelessWidget {
     Widget buttonWidget;
     Container textDisplay;
 
+    /// Experience buttons are built as a list of widgets inside a card.
+
+    /// First module - text display. Only used when the user has it set and
+    /// when there's text to display
+
     // We only want the text to display if there exists a count on the button
-    if(data.numberOfTimesRidden > 0){
+    if(data.numberOfTimesRidden > 0 && parentPark.incrementorEnabled){
       textDisplay = Container(
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 8.0),
@@ -26,29 +34,41 @@ class ExperienceButton extends StatelessWidget {
       children.add(textDisplay);
     }
 
-    IconData buttonIcon;
+    /// Establishing button style - used for showing the user exactly what's going on
+
     Color buttonColor;
+    Widget iconWidget;
 
     // Text will display regardless of enabled. Our button, however, does differ
 
-    if(enabled){
+    if(!ignored){
       buttonColor = Theme.of(context).primaryColor;
       if(data.numberOfTimesRidden > 0){
         // Plus button is displayed when there's at least one count
-        buttonIcon = Icons.add_circle;
+        iconWidget = Icon(FontAwesomeIcons.solidCheckCircle, color: buttonColor, size: 32.0,);
       } else {
-        // Standard button is displayed when there's no count
-        buttonIcon = Icons.arrow_drop_down_circle;
+        // iOS has a circle with a border. I can't do that easily with icons,
+        // so I just stacked two appropriate ones on top of each other.
+        // The padding inset of 2 is used to mimic the other normal icons appropriately.
+        iconWidget = Padding(
+          padding: EdgeInsets.all(2.0),
+          child: Stack(
+            children: <Widget>[
+              Icon(FontAwesomeIcons.solidCircle, color: Color.fromARGB(255, 135, 207, 129), size: 32.0,),
+              Icon(FontAwesomeIcons.circle, color: buttonColor, size: 32.0)
+            ],
+          ),
+        );
       }
     } else {
-      // X-button is displayed when the ride is defunct/disabled
-      buttonIcon = Icons.remove_circle;
-      buttonColor = Colors.grey;
+      // X-button is displayed when the ride is ignored
+      iconWidget = Icon(FontAwesomeIcons.solidTimesCircle, color: Colors.grey, size: 32.0,);
     }
 
 
-    buttonWidget = Container(
-        child: Icon(buttonIcon, color: buttonColor)
+    buttonWidget = AspectRatio(
+      aspectRatio: 1.0,
+      child: iconWidget,
     );
 
     children.add(buttonWidget);
@@ -60,11 +80,8 @@ class ExperienceButton extends StatelessWidget {
         minWidth: 32.0
       ),
       child: Card(
-        child: Padding(
-          padding: const EdgeInsets.all(2.0),
-          child: Row(
-            children: children,
-          ),
+        child: Row(
+          children: children,
         ),
       ),
     );

--- a/lib/widgets/experience_button.dart
+++ b/lib/widgets/experience_button.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
+import '../data/attraction_structures.dart';
 
-class AttractionButton extends StatelessWidget {
-  AttractionButton({this.enabled, this.count, this.onTap});
+class ExperienceButton extends StatelessWidget {
+  ExperienceButton({this.data, this.enabled});
 
+  final FirebaseAttraction data;
   final bool enabled;
-  final num count;
-  final Function onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -14,11 +14,11 @@ class AttractionButton extends StatelessWidget {
     Container textDisplay;
 
     // We only want the text to display if there exists a count on the button
-    if(count > 0){
+    if(data.numberOfTimesRidden > 0){
       textDisplay = Container(
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 8.0),
-          child: Text(count.toString(),
+          child: Text(data.numberOfTimesRidden.toString(),
             textAlign: TextAlign.right,
             textScaleFactor: 1.3),
         )
@@ -33,7 +33,7 @@ class AttractionButton extends StatelessWidget {
 
     if(enabled){
       buttonColor = Theme.of(context).primaryColor;
-      if(count > 0){
+      if(data.numberOfTimesRidden > 0){
         // Plus button is displayed when there's at least one count
         buttonIcon = Icons.add_circle;
       } else {

--- a/lib/widgets/experience_button.dart
+++ b/lib/widgets/experience_button.dart
@@ -3,14 +3,11 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import '../data/attraction_structures.dart';
 import '../data/park_structures.dart';
 
-enum ExperienceAction {
-  ADD,
-  REMOVE,
-  SET
-}
+enum ExperienceAction { ADD, REMOVE, SET }
 
 class ExperienceButton extends StatelessWidget {
-  ExperienceButton({this.parentPark, this.data, this.ignored, this.interactHandler});
+  ExperienceButton(
+      {this.parentPark, this.data, this.ignored, this.interactHandler});
 
   final FirebasePark parentPark;
   final FirebaseAttraction data;
@@ -29,15 +26,13 @@ class ExperienceButton extends StatelessWidget {
     /// when there's text to display
 
     // We only want the text to display if there exists a count on the button
-    if(data.numberOfTimesRidden > 0 && parentPark.incrementorEnabled){
+    if (data.numberOfTimesRidden > 0 && parentPark.incrementorEnabled) {
       textDisplay = Container(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 8.0),
-          child: Text(data.numberOfTimesRidden.toString(),
-            textAlign: TextAlign.right,
-            textScaleFactor: 1.3),
-        )
-      );
+          child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8.0),
+        child: Text(data.numberOfTimesRidden.toString(),
+            textAlign: TextAlign.right, textScaleFactor: 1.3),
+      ));
       children.add(textDisplay);
     }
 
@@ -48,11 +43,15 @@ class ExperienceButton extends StatelessWidget {
 
     // Text will display regardless of enabled. Our button, however, does differ
 
-    if(!ignored){
+    if (!ignored) {
       buttonColor = Theme.of(context).primaryColor;
-      if(data.numberOfTimesRidden > 0){
+      if (data.numberOfTimesRidden > 0) {
         // Plus button is displayed when there's at least one count
-        iconWidget = Icon(FontAwesomeIcons.solidCheckCircle, color: buttonColor, size: 32.0,);
+        iconWidget = Icon(
+          FontAwesomeIcons.solidCheckCircle,
+          color: buttonColor,
+          size: 32.0,
+        );
       } else {
         // iOS has a circle with a border. I can't do that easily with icons,
         // so I just stacked two appropriate ones on top of each other.
@@ -61,7 +60,11 @@ class ExperienceButton extends StatelessWidget {
           padding: EdgeInsets.all(2.0),
           child: Stack(
             children: <Widget>[
-              Icon(FontAwesomeIcons.solidCircle, color: Color.fromARGB(255, 135, 207, 129), size: 32.0,),
+              Icon(
+                FontAwesomeIcons.solidCircle,
+                color: Color.fromARGB(255, 135, 207, 129),
+                size: 32.0,
+              ),
               Icon(FontAwesomeIcons.circle, color: buttonColor, size: 32.0)
             ],
           ),
@@ -69,33 +72,40 @@ class ExperienceButton extends StatelessWidget {
       }
     } else {
       // X-button is displayed when the ride is ignored
-      iconWidget = Icon(FontAwesomeIcons.solidTimesCircle, color: Colors.grey, size: 32.0,);
+      iconWidget = Icon(
+        FontAwesomeIcons.solidTimesCircle,
+        color: Colors.grey,
+        size: 32.0,
+      );
     }
 
-
     buttonWidget = AspectRatio(
-      aspectRatio: 1.0,
-      child: iconWidget,
-    );
+        aspectRatio: 1.0,
+        child: iconWidget,
+      );
 
     children.add(buttonWidget);
 
-    return GestureDetector(
-      child: Container(
-        constraints: BoxConstraints(
-          maxHeight: 44,
-          minHeight: 44.0,
-          minWidth: 32.0
-        ),
-        child: Card(
+    /// Note about latency
+    /// With any gesturedetector (as an inkwell is), behavior varies depending on
+    /// whether or not logic for doubletap is present. If it is, there'll be a
+    /// delay before onTap is called so it can check if the onTap is satisfied.
+    ///
+    /// This is unfortunate, as it makes onTap feel slow
+
+    return Container(
+      constraints:
+          BoxConstraints(maxHeight: 44, minHeight: 44.0, minWidth: 32.0),
+      child: Card(
+        child: InkWell(
           child: Row(
             children: children,
           ),
+          onTap: () => interactHandler(ExperienceAction.ADD, data),
+          onDoubleTap: () => interactHandler(ExperienceAction.SET, data),
+          onLongPress: () => interactHandler(ExperienceAction.REMOVE, data),
         ),
       ),
-      onTap: () => interactHandler(ExperienceAction.ADD, data),
-      onDoubleTap: () => interactHandler(ExperienceAction.SET, data),
-      onLongPress: () => interactHandler(ExperienceAction.REMOVE, data),
     );
   }
 }

--- a/lib/widgets/experience_button.dart
+++ b/lib/widgets/experience_button.dart
@@ -102,7 +102,7 @@ class ExperienceButton extends StatelessWidget {
             children: children,
           ),
           onTap: () => interactHandler(ExperienceAction.ADD, data),
-          onDoubleTap: () => interactHandler(ExperienceAction.SET, data),
+          //onDoubleTap: () => interactHandler(ExperienceAction.SET, data),
           onLongPress: () => interactHandler(ExperienceAction.REMOVE, data),
         ),
       ),

--- a/lib/widgets/experience_button.dart
+++ b/lib/widgets/experience_button.dart
@@ -46,9 +46,9 @@ class ExperienceButton extends StatelessWidget {
     if (!ignored) {
       buttonColor = Theme.of(context).primaryColor;
       if (data.numberOfTimesRidden > 0) {
-        // Plus button is displayed when there's at least one count
+        // Plus button is displayed when there's at least one count and incrementor isn't on
         iconWidget = Icon(
-          FontAwesomeIcons.solidCheckCircle,
+          parentPark.incrementorEnabled ? FontAwesomeIcons.plusCircle : FontAwesomeIcons.solidCheckCircle,
           color: buttonColor,
           size: 32.0,
         );
@@ -103,7 +103,7 @@ class ExperienceButton extends StatelessWidget {
           ),
           onTap: () => interactHandler(ExperienceAction.ADD, data),
           //onDoubleTap: () => interactHandler(ExperienceAction.SET, data),
-          onLongPress: () => interactHandler(ExperienceAction.REMOVE, data),
+          onLongPress: () => interactHandler(ExperienceAction.SET, data), // If a user wants to remove a value, they have to set it. I doubt they use the single remove often.
         ),
       ),
     );

--- a/lib/widgets/experience_button.dart
+++ b/lib/widgets/experience_button.dart
@@ -3,12 +3,19 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import '../data/attraction_structures.dart';
 import '../data/park_structures.dart';
 
+enum ExperienceAction {
+  ADD,
+  REMOVE,
+  SET
+}
+
 class ExperienceButton extends StatelessWidget {
-  ExperienceButton({this.parentPark, this.data, this.ignored});
+  ExperienceButton({this.parentPark, this.data, this.ignored, this.interactHandler});
 
   final FirebasePark parentPark;
   final FirebaseAttraction data;
   final bool ignored;
+  final Function(ExperienceAction, FirebaseAttraction) interactHandler;
 
   @override
   Widget build(BuildContext context) {
@@ -73,17 +80,22 @@ class ExperienceButton extends StatelessWidget {
 
     children.add(buttonWidget);
 
-    return Container(
-      constraints: BoxConstraints(
-        maxHeight: 44,
-        minHeight: 44.0,
-        minWidth: 32.0
-      ),
-      child: Card(
-        child: Row(
-          children: children,
+    return GestureDetector(
+      child: Container(
+        constraints: BoxConstraints(
+          maxHeight: 44,
+          minHeight: 44.0,
+          minWidth: 32.0
+        ),
+        child: Card(
+          child: Row(
+            children: children,
+          ),
         ),
       ),
+      onTap: () => interactHandler(ExperienceAction.ADD, data),
+      onDoubleTap: () => interactHandler(ExperienceAction.SET, data),
+      onLongPress: () => interactHandler(ExperienceAction.REMOVE, data),
     );
   }
 }

--- a/lib/widgets/firebase_attraction_list.dart
+++ b/lib/widgets/firebase_attraction_list.dart
@@ -5,6 +5,7 @@ import 'package:flutter_slidable/flutter_slidable.dart';
 import '../data/attraction_structures.dart';
 import '../data/park_structures.dart';
 import '../widgets/attraction_list_entry.dart';
+import '../widgets/experience_button.dart';
 
 class FirebaseAttractionListView extends StatefulWidget {
   FirebaseAttractionListView(
@@ -13,7 +14,8 @@ class FirebaseAttractionListView extends StatefulWidget {
       this.headedList,
       this.parentPark,
       this.ignoreCallback,
-      this.interactHandler});
+      this.experienceHandler,
+      this.countHandler});
 
   final Query attractionQuery;
   final Query ignoreQuery;
@@ -21,8 +23,9 @@ class FirebaseAttractionListView extends StatefulWidget {
   final List<dynamic> headedList;
   final FirebasePark parentPark;
 
-  final Function ignoreCallback;
-  final Function interactHandler;
+  final Function(BluehostAttraction target, bool currentState) ignoreCallback;
+  final Function(ExperienceAction, FirebaseAttraction) experienceHandler;
+  final Function(List<FirebaseAttraction> userData, List<int> ignoreData) countHandler;
 
   @override
   _FirebaseAttractionListViewState createState() =>
@@ -35,6 +38,7 @@ class _FirebaseAttractionListViewState
   FirebaseList _ignoreList;
 
   List<FirebaseAttraction> _builtAttractionList;
+  List<int> _builtIgnoreList;
 
   bool _ignoreLoaded = false;
   bool _attractionLoaded = false;
@@ -117,6 +121,7 @@ class _FirebaseAttractionListViewState
       _builtAttractionList.add(parsed);
     });
 
+    _builtIgnoreList = List<int>();
     _ignoreList.forEach((snap) {
       bool newEntry = false;
 
@@ -131,6 +136,7 @@ class _FirebaseAttractionListViewState
 
       target.ignored = true;
       if (newEntry) _builtAttractionList.add(target);
+      _builtIgnoreList.add(targetID);
     });
   }
 
@@ -155,7 +161,7 @@ class _FirebaseAttractionListViewState
     return AttractionListEntry(
       attractionData: target,
       parentPark: widget.parentPark,
-      interactHandler: widget.interactHandler,
+      experienceHandler: widget.experienceHandler,
       ignoreCallback: widget.ignoreCallback,
       slidableController: _slidableController,
       userData: attraction,
@@ -166,6 +172,7 @@ class _FirebaseAttractionListViewState
   Widget build(BuildContext context) {
     if (_ignoreLoaded && _attractionLoaded) {
       _buildLists();
+      widget.countHandler(_builtAttractionList, _builtIgnoreList);
       print("Rebuilding");
       return ListView.builder(
         itemCount: widget.headedList.length,

--- a/lib/widgets/firebase_attraction_list.dart
+++ b/lib/widgets/firebase_attraction_list.dart
@@ -1,0 +1,187 @@
+import 'package:firebase_database/firebase_database.dart';
+import 'package:firebase_database/ui/firebase_list.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_slidable/flutter_slidable.dart';
+import '../data/attraction_structures.dart';
+import '../data/park_structures.dart';
+import '../widgets/attraction_list_entry.dart';
+
+class FirebaseAttractionListView extends StatefulWidget {
+  FirebaseAttractionListView(
+      {this.attractionQuery,
+      this.ignoreQuery,
+      this.headedList,
+      this.parentPark,
+      this.ignoreCallback,
+      this.interactHandler});
+
+  final Query attractionQuery;
+  final Query ignoreQuery;
+
+  final List<dynamic> headedList;
+  final FirebasePark parentPark;
+
+  final Function ignoreCallback;
+  final Function interactHandler;
+
+  @override
+  _FirebaseAttractionListViewState createState() =>
+      _FirebaseAttractionListViewState();
+}
+
+class _FirebaseAttractionListViewState
+    extends State<FirebaseAttractionListView> {
+  FirebaseList _attractionList;
+  FirebaseList _ignoreList;
+
+  List<FirebaseAttraction> _builtAttractionList;
+  List<int> _builtIgnoreList;
+
+  bool _ignoreLoaded = false;
+  bool _attractionLoaded = false;
+
+  final SlidableController _slidableController = SlidableController();
+
+  void _onAttractionAdded(int index, DataSnapshot snap) {
+    if (!_attractionLoaded) return;
+    print("AttractionAdded Callback index: $index");
+    if (mounted) setState(() {});
+  }
+
+  void _onAttractionRemoved(int index, DataSnapshot snap) {
+    print("AttractionRemoved Callback index: $index");
+    if (mounted) setState(() {});
+  }
+
+  void _onAttractionChanged(int index, DataSnapshot snap) {
+    print("AttractionChanged Callback index: $index");
+    if (mounted) setState(() {});
+  }
+
+  void _onAttractionValue(DataSnapshot snap) {
+    print("AttractionValue");
+    if (mounted)
+      setState(() {
+        _attractionLoaded = true;
+      });
+  }
+
+  void _onIgnoreAdded(int index, DataSnapshot snap) {
+    if (!_ignoreLoaded) return;
+    print("IgnoreAdded index: $index");
+    print("IgnoreAdded data: ${snap.value["rideID"]}");
+    if (mounted) setState(() {});
+  }
+
+  void _onIgnoreRemoved(int index, DataSnapshot snap) {
+    print("Ignore removed index: $index");
+    if (mounted) setState(() {});
+  }
+
+  void _onIgnoreChanged(int index, DataSnapshot snap) {
+    print("Ignore changed index: $index");
+    if (mounted) setState(() {});
+  }
+
+  void _onIgnoreValue(DataSnapshot snap) {
+    print("Ignore value");
+    if (mounted)
+      setState(() {
+        _ignoreLoaded = true;
+      });
+  }
+
+  @override
+  void initState() {
+    print("List initialized");
+    super.initState();
+    _attractionList = FirebaseList(
+        query: widget.attractionQuery,
+        onChildAdded: _onAttractionAdded,
+        onChildChanged: _onAttractionChanged,
+        onChildRemoved: _onAttractionRemoved,
+        onValue: _onAttractionValue);
+    _ignoreList = FirebaseList(
+        query: widget.ignoreQuery,
+        onChildAdded: _onIgnoreAdded,
+        onChildChanged: _onIgnoreChanged,
+        onChildRemoved: _onIgnoreRemoved,
+        onValue: _onIgnoreValue);
+  }
+
+  void _buildLists() {
+    _builtAttractionList = List<FirebaseAttraction>();
+    _attractionList.forEach((snap) {
+      FirebaseAttraction parsed =
+          FirebaseAttraction.fromMap(Map.from(snap.value));
+
+      _builtAttractionList.add(parsed);
+    });
+
+    _ignoreList.forEach((snap) {
+      bool newEntry = false;
+
+      int targetID = snap.value["rideID"];
+      FirebaseAttraction target = _builtAttractionList
+          .firstWhere((testPark) => testPark.rideID == targetID, orElse: () {
+        // This only occurs when a park is ignored and has no other data for it.
+        // We need to create this data ourselves, and know to append it to the rest of the data.
+        newEntry = true;
+        return FirebaseAttraction(rideID: targetID);
+      });
+
+      target.ignored = true;
+      if (newEntry) _builtAttractionList.add(target);
+    });
+  }
+
+  Widget _entryBuilder(BuildContext context, int index) {
+    if (widget.headedList[index] is String) {
+      return Container(
+        height: 20.0,
+        width: double.infinity,
+        color: Colors.grey[200],
+        child: Padding(
+          padding: EdgeInsets.only(left: 8.0),
+          child: Text(widget.headedList[index]),
+        ),
+      );
+    }
+
+    BluehostAttraction target = widget.headedList[index] as BluehostAttraction;
+    FirebaseAttraction attraction = getFirebaseAttractionFromList(
+            _builtAttractionList, target.attractionID) ??
+        FirebaseAttraction(rideID: target.attractionID);
+
+    return AttractionListEntry(
+      attractionData: target,
+      parentPark: widget.parentPark,
+      interactHandler: widget.interactHandler,
+      ignoreCallback: widget.ignoreCallback,
+      slidableController: _slidableController,
+      userData: attraction,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_ignoreLoaded && _attractionLoaded) {
+      _buildLists();
+      print("Rebuilding");
+      return ListView.builder(
+        itemCount: widget.headedList.length,
+        itemBuilder: _entryBuilder,
+      );
+    } else {
+      return Center(child: CircularProgressIndicator());
+    }
+  }
+
+  @override
+  void dispose() {
+    _ignoreList.clear();
+    _attractionList.clear();
+
+    super.dispose();
+  }
+}

--- a/lib/widgets/firebase_attraction_list.dart
+++ b/lib/widgets/firebase_attraction_list.dart
@@ -35,7 +35,6 @@ class _FirebaseAttractionListViewState
   FirebaseList _ignoreList;
 
   List<FirebaseAttraction> _builtAttractionList;
-  List<int> _builtIgnoreList;
 
   bool _ignoreLoaded = false;
   bool _attractionLoaded = false;

--- a/lib/widgets/park_progress.dart
+++ b/lib/widgets/park_progress.dart
@@ -146,7 +146,7 @@ class RewardProgressBar extends StatelessWidget{
   Widget build(BuildContext context) {
     num ratio;
     if (denominator == 0) {
-      ratio = 0;
+      ratio = 0.01;
     } else {
       ratio = numerator / denominator;
     }

--- a/lib/widgets/park_progress.dart
+++ b/lib/widgets/park_progress.dart
@@ -15,12 +15,6 @@ class ParkProgressListItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    double progress;
-    if (numRides == 0) {
-      progress = 0.0;
-    } else {
-      progress = numRidden / numRides;
-    }
 
     return Container(
         // Hard-coding the size of the box in dp. This may change later.
@@ -141,7 +135,8 @@ class ParkProgressFullBar extends StatelessWidget {
   }
 }
 
-class RewardProgressBar extends StatelessWidget {
+// TODO: MAKE ANIMATED
+class RewardProgressBar extends StatelessWidget{
   RewardProgressBar({this.numerator, this.denominator});
 
   final num numerator;

--- a/lib/widgets/park_progress.dart
+++ b/lib/widgets/park_progress.dart
@@ -65,8 +65,8 @@ class FullParkProgressBar extends StatelessWidget {
           // Background bar, full width
           // Text overlay - Progress
           _buildProgressLabel(context),
-          showDefunct ? _buildDefunctLabel(context) : Container(),
-          showSeasonal ? _buildSeasonalLabel(context) : Container()
+          showDefunct && (defunctCount != 0) ? _buildDefunctLabel(context) : Container(),
+          showSeasonal && (seasonalCount != 0) ? _buildSeasonalLabel(context) : Container()
         ],
       ),
     );

--- a/lib/widgets/set_experience_box.dart
+++ b/lib/widgets/set_experience_box.dart
@@ -61,19 +61,25 @@ class _SetExperienceDialogBoxState extends State<SetExperienceDialogBox> {
                   _buildButton(_ButtonType.SUBTRACT_MANY),
                   Container(
                     width: 50,
-                    child: TextField(
-                      controller: _editingController,
-                      textAlign: TextAlign.center,
-                      keyboardType: TextInputType.number,
-                      decoration: InputDecoration(
-                        border: InputBorder.none,
+                    child: Container(
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(5.0),
+                        color: Colors.grey[100]
                       ),
-                      onChanged: (value) {
-                        currentCount = int.parse(value);
-                      },
-                      inputFormatters: [
-                        LengthLimitingTextInputFormatter(4)
-                      ],
+                      child: TextField(
+                        controller: _editingController,
+                        textAlign: TextAlign.center,
+                        keyboardType: TextInputType.number,
+                        decoration: InputDecoration(
+                          border: InputBorder.none
+                        ),
+                        onChanged: (value) {
+                          currentCount = int.parse(value);
+                        },
+                        inputFormatters: [
+                          LengthLimitingTextInputFormatter(4)
+                        ],
+                      ),
                     ),
                   ),
                   _buildButton(_ButtonType.ADD_MANY),

--- a/lib/widgets/set_experience_box.dart
+++ b/lib/widgets/set_experience_box.dart
@@ -39,7 +39,14 @@ class _SetExperienceDialogBoxState extends State<SetExperienceDialogBox> {
 
   @override
   Widget build(BuildContext context) {
+    // Establishing the text every time we build ensures that the text is always up to date.
     _editingController.text = currentCount.toString();
+
+    // Used to direct the user's cursor to the end of the text field each time the widget rebuilds and the user is editing.
+    // This means it typically happens when the user first taps on the widget and the keyboard rolls up.
+    _editingController.selection =
+        TextSelection.collapsed(offset: currentCount.toString().length);
+
     return Dialog(
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(15)),
         child: Padding(
@@ -47,6 +54,7 @@ class _SetExperienceDialogBoxState extends State<SetExperienceDialogBox> {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
+              // Title/header section
               Padding(
                 padding: const EdgeInsets.only(bottom: 16.0, top: 8.0),
                 child: Text(
@@ -54,43 +62,45 @@ class _SetExperienceDialogBoxState extends State<SetExperienceDialogBox> {
                   style: Theme.of(context).textTheme.title,
                 ),
               ),
+
+              // Section responsible for direct user input/interaction
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: <Widget>[
-                  _buildButton(_ButtonType.SUBTRACT_ONE),
-                  _buildButton(_ButtonType.SUBTRACT_MANY),
+                  _buildInputIconButton(_ButtonType.SUBTRACT_ONE),
+                  _buildInputIconButton(_ButtonType.SUBTRACT_MANY),
                   Container(
                     width: 60,
                     child: Container(
                       decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(5.0),
-                        color: Colors.grey[100]
-                      ),
+                          borderRadius: BorderRadius.circular(5.0),
+                          color: Colors.grey[100]),
                       child: TextField(
                         controller: _editingController,
                         textAlign: TextAlign.center,
                         keyboardType: TextInputType.number,
-                        decoration: InputDecoration(
-                          border: InputBorder.none
-                        ),
+                        decoration: InputDecoration(border: InputBorder.none),
                         onChanged: (value) {
                           currentCount = int.parse(value);
                         },
-                        inputFormatters: [
-                          LengthLimitingTextInputFormatter(4)
-                        ],
                       ),
                     ),
                   ),
-                  _buildButton(_ButtonType.ADD_MANY),
-                  _buildButton(_ButtonType.ADD_ONE)
+                  _buildInputIconButton(_ButtonType.ADD_MANY),
+                  _buildInputIconButton(_ButtonType.ADD_ONE)
                 ],
               ),
+
+              // Confirm/cancel buttons for user input. Tapping on the background also cancels, but just in case.
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceAround,
                 children: <Widget>[
-                  _buildConfirmButton(FontAwesomeIcons.times, Colors.grey[350], () => Navigator.of(context).pop(widget.originalCount)),
-                  _buildConfirmButton(FontAwesomeIcons.check, Theme.of(context).buttonColor, () => Navigator.of(context).pop(currentCount))
+                  _buildConfirmButton(FontAwesomeIcons.times, Colors.grey[350],
+                      () => Navigator.of(context).pop(widget.originalCount)),
+                  _buildConfirmButton(
+                      FontAwesomeIcons.check,
+                      Theme.of(context).buttonColor,
+                      () => Navigator.of(context).pop(currentCount))
                 ],
               )
             ],
@@ -98,22 +108,26 @@ class _SetExperienceDialogBoxState extends State<SetExperienceDialogBox> {
         ));
   }
 
-  Widget _buildButton(_ButtonType type) {
+  // Used in the manipulation of user data
+  Widget _buildInputIconButton(_ButtonType type) {
     return IconButton(
       icon: Icon(_buttonImageMap[type]),
       onPressed: () {
         FocusScope.of(context).requestFocus(new FocusNode());
         switch (type) {
+          // Addition cases are easy - we really can't overflow with this.
           case _ButtonType.ADD_MANY:
             setState(() {
               currentCount += 5;
             });
             break;
+
           case _ButtonType.ADD_ONE:
             setState(() {
               currentCount++;
             });
             break;
+
           case _ButtonType.SUBTRACT_MANY:
             int valueRemoved = 5;
             // If we're going to go negative, only remove as much as is needed
@@ -126,6 +140,7 @@ class _SetExperienceDialogBoxState extends State<SetExperienceDialogBox> {
               currentCount -= valueRemoved;
             });
             break;
+
           case _ButtonType.SUBTRACT_ONE:
             // Keeping us from going negative
             if (currentCount - 1 < 0) return;
@@ -138,7 +153,9 @@ class _SetExperienceDialogBoxState extends State<SetExperienceDialogBox> {
     );
   }
 
-  Widget _buildConfirmButton(IconData data, Color iconColor, Function tapHandler){
+  // Simple wrapper to clean up the creation of confirmation/cancel buttons
+  Widget _buildConfirmButton(
+      IconData data, Color iconColor, Function tapHandler) {
     return IconButton(
       icon: Icon(data, color: iconColor, size: 32),
       onPressed: tapHandler,

--- a/lib/widgets/set_experience_box.dart
+++ b/lib/widgets/set_experience_box.dart
@@ -60,7 +60,7 @@ class _SetExperienceDialogBoxState extends State<SetExperienceDialogBox> {
                   _buildButton(_ButtonType.SUBTRACT_ONE),
                   _buildButton(_ButtonType.SUBTRACT_MANY),
                   Container(
-                    width: 50,
+                    width: 60,
                     child: Container(
                       decoration: BoxDecoration(
                         borderRadius: BorderRadius.circular(5.0),

--- a/lib/widgets/set_experience_box.dart
+++ b/lib/widgets/set_experience_box.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+enum _ButtonType {
+  SUBTRACT_ONE,
+  SUBTRACT_MANY,
+  ADD_ONE,
+  ADD_MANY,
+}
+
+const Map<_ButtonType, IconData> _buttonImageMap = {
+  _ButtonType.SUBTRACT_ONE: FontAwesomeIcons.angleLeft,
+  _ButtonType.SUBTRACT_MANY: FontAwesomeIcons.angleDoubleLeft,
+  _ButtonType.ADD_ONE: FontAwesomeIcons.angleRight,
+  _ButtonType.ADD_MANY: FontAwesomeIcons.angleDoubleRight
+};
+
+class SetExperienceDialogBox extends StatefulWidget {
+  SetExperienceDialogBox(this.originalCount);
+
+  final num originalCount;
+
+  @override
+  _SetExperienceDialogBoxState createState() => _SetExperienceDialogBoxState();
+}
+
+class _SetExperienceDialogBoxState extends State<SetExperienceDialogBox> {
+  TextEditingController _editingController;
+
+  num currentCount;
+
+  @override
+  void initState() {
+    currentCount = widget.originalCount;
+    _editingController = TextEditingController(text: currentCount.toString());
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    _editingController.text = currentCount.toString();
+    return Dialog(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(15)),
+        child: Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Padding(
+                padding: const EdgeInsets.only(bottom: 16.0, top: 8.0),
+                child: Text(
+                  "Set Experience Count",
+                  style: Theme.of(context).textTheme.title,
+                ),
+              ),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: <Widget>[
+                  _buildButton(_ButtonType.SUBTRACT_ONE),
+                  _buildButton(_ButtonType.SUBTRACT_MANY),
+                  Container(
+                    width: 50,
+                    child: TextField(
+                      controller: _editingController,
+                      textAlign: TextAlign.center,
+                      keyboardType: TextInputType.number,
+                      decoration: InputDecoration(
+                        border: InputBorder.none,
+                      ),
+                      onChanged: (value) {
+                        currentCount = int.parse(value);
+                      },
+                      inputFormatters: [
+                        LengthLimitingTextInputFormatter(4)
+                      ],
+                    ),
+                  ),
+                  _buildButton(_ButtonType.ADD_MANY),
+                  _buildButton(_ButtonType.ADD_ONE)
+                ],
+              ),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                children: <Widget>[
+                  _buildConfirmButton(FontAwesomeIcons.times, Colors.grey[350], () => Navigator.of(context).pop(widget.originalCount)),
+                  _buildConfirmButton(FontAwesomeIcons.check, Theme.of(context).buttonColor, () => Navigator.of(context).pop(currentCount))
+                ],
+              )
+            ],
+          ),
+        ));
+  }
+
+  Widget _buildButton(_ButtonType type) {
+    return IconButton(
+      icon: Icon(_buttonImageMap[type]),
+      onPressed: () {
+        FocusScope.of(context).requestFocus(new FocusNode());
+        switch (type) {
+          case _ButtonType.ADD_MANY:
+            setState(() {
+              currentCount += 5;
+            });
+            break;
+          case _ButtonType.ADD_ONE:
+            setState(() {
+              currentCount++;
+            });
+            break;
+          case _ButtonType.SUBTRACT_MANY:
+            int valueRemoved = 5;
+            // If we're going to go negative, only remove as much as is needed
+            // to take us to zero.
+            if (currentCount - valueRemoved < 0) {
+              valueRemoved = currentCount;
+            }
+
+            setState(() {
+              currentCount -= valueRemoved;
+            });
+            break;
+          case _ButtonType.SUBTRACT_ONE:
+            // Keeping us from going negative
+            if (currentCount - 1 < 0) return;
+            setState(() {
+              currentCount--;
+            });
+            break;
+        }
+      },
+    );
+  }
+
+  Widget _buildConfirmButton(IconData data, Color iconColor, Function tapHandler){
+    return IconButton(
+      icon: Icon(data, color: iconColor, size: 32),
+      onPressed: tapHandler,
+    );
+  }
+}

--- a/lib/widgets/submit_button.dart
+++ b/lib/widgets/submit_button.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
 
 class SubmitButton extends StatelessWidget {
-  SubmitButton({this.text, this.onTap});
+  SubmitButton({this.text, this.onTap, this.insets});
 
   final String text;
   final Function onTap;
+  final EdgeInsets insets;
 
   @override
   Widget build(BuildContext context) {
@@ -24,7 +25,7 @@ class SubmitButton extends StatelessWidget {
           highlightColor: Colors.transparent,
           splashColor: Theme.of(context).accentColor,
           child: Padding(
-            padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 42),
+            padding: insets ?? const EdgeInsets.symmetric(vertical: 10, horizontal: 42),
             child: Text(text.toUpperCase(), style: TextStyle(
               color: Colors.white,
               fontSize: 25.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,6 +57,9 @@ dependencies:
   # Used in attractions views for sticky headers
   sticky_headers: 0.1.7
 
+  # Alternate sticky header package (more efficient?)
+  sticky_header_list: 1.0.6
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
This is the initial implemention of the attractions page for LogRide. This allows users to view any park, the park's attractions, and increment/decrement/set the number of times they've experienced an attraction. Users can also set whether or not they want to have their ride times incremented, or just be on/off.

Things to do: Settings page, Info panel for parks, Info panel for attractions, ~~defunct ridden / seasonal ridden labels~~, ~~and the updating of the progress for the park~~

Also to do: Animations for button expansion and the ~~progress bar.~~